### PR TITLE
- Fixing typo on Fragment tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,9 +372,8 @@ It must be called in `onCreate` method.
 override fun onCreate(savedInstanceState: Bundle?) {
   super.onCreate(savedInstanceState)
 
- TransformationLayout.Params.
-    val params = arguments?.getParcelable<TransformationLayout.Params>("TransformationParams")
-    onTransformationEndContainer(params)
+  val params = arguments?.getParcelable<TransformationLayout.Params>("TransformationParams")
+  onTransformationEndContainer(params)
 }
 ```
 Here is the Java way.


### PR DESCRIPTION
The tutorial for fragments had the Kotlin syntax messed up.

This really doesn't effect the code in any meaningful way, it is just for the tutorial on the readme page.